### PR TITLE
[#31] 회원가입 로직 수정, 로그아웃 로직 추가

### DIFF
--- a/src/main/java/com/e2i1/linkeepserver/common/error/ErrorCode.java
+++ b/src/main/java/com/e2i1/linkeepserver/common/error/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode{
 
     // 유저 관련 에러 코드
     USER_NOT_FOUND(34040,HttpStatus.NOT_FOUND,  "사용자를 찾을 수 없음"),
+    NICKNAME_DUPLICATED(34000,HttpStatus.BAD_REQUEST,  "닉네임이 중복됩니다."),
 
     // 모음집 관련 에러 코드
     COLLECTION_NOT_FOUND(44040,HttpStatus.NOT_FOUND, "모음집을 찾을 수 없음"),

--- a/src/main/java/com/e2i1/linkeepserver/config/WebConfig.java
+++ b/src/main/java/com/e2i1/linkeepserver/config/WebConfig.java
@@ -20,7 +20,8 @@ public class WebConfig implements WebMvcConfigurer {
         "/",
         "favicon.ico",
         "/error",
-        "/api/users/login"
+        "/api/users/login",
+        "/api/users/register"
     );
 
     private final List<String> SWAGGER = List.of(

--- a/src/main/java/com/e2i1/linkeepserver/domain/token/entity/BlackList.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/token/entity/BlackList.java
@@ -1,0 +1,25 @@
+package com.e2i1.linkeepserver.domain.token.entity;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import com.e2i1.linkeepserver.common.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "token_black_list")
+public class BlackList extends BaseEntity {
+
+    private String invalidToken;
+
+}

--- a/src/main/java/com/e2i1/linkeepserver/domain/token/repository/BlackListRepository.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/token/repository/BlackListRepository.java
@@ -1,0 +1,10 @@
+package com.e2i1.linkeepserver.domain.token.repository;
+
+import com.e2i1.linkeepserver.domain.token.entity.BlackList;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface BlackListRepository extends JpaRepository<BlackList, Long> {
+
+    BlackList findByInvalidToken(String token);
+}

--- a/src/main/java/com/e2i1/linkeepserver/domain/token/service/TokenService.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/token/service/TokenService.java
@@ -3,19 +3,21 @@ package com.e2i1.linkeepserver.domain.token.service;
 import com.e2i1.linkeepserver.common.error.ErrorCode;
 import com.e2i1.linkeepserver.common.exception.ApiException;
 import com.e2i1.linkeepserver.domain.token.dto.TokenDTO;
+import com.e2i1.linkeepserver.domain.token.entity.BlackList;
 import com.e2i1.linkeepserver.domain.token.ifs.TokenHelperIfs;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
+import com.e2i1.linkeepserver.domain.token.repository.BlackListRepository;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
 public class TokenService {
 
     private final TokenHelperIfs tokenHelperIfs;
+    private final BlackListRepository blackListRepository;
 
     public TokenDTO issueAccessToken(Long userId) {
         HashMap<String, Object> data = new HashMap<>();
@@ -39,9 +41,19 @@ public class TokenService {
 
         // userId 없을 수 있음 -> null check
         Objects.requireNonNull(userId, () -> {
-            throw new ApiException(ErrorCode.NULL_POINT);
+            throw new ApiException(ErrorCode.INVALID_TOKEN);
         });
 
+        // 해당 token이 blacklist에 저장되어 있는지 확인 -> 저장되어 있으면 예외 던짐
+        BlackList invalidToken = blackListRepository.findByInvalidToken(token);
+        if (invalidToken != null) {
+            throw new ApiException(ErrorCode.INVALID_TOKEN, "로그아웃 된 token입니다.");
+        }
+
         return Long.parseLong(userId.toString());
+    }
+
+    public void saveBlackList(BlackList blackList) {
+        blackListRepository.save(blackList);
     }
 }

--- a/src/main/java/com/e2i1/linkeepserver/domain/users/business/UsersBusiness.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/users/business/UsersBusiness.java
@@ -16,8 +16,10 @@ import com.e2i1.linkeepserver.domain.users.converter.UsersConverter;
 import com.e2i1.linkeepserver.domain.users.dto.EditProfileReqDTO;
 import com.e2i1.linkeepserver.domain.users.dto.LinkHomeResDTO;
 import com.e2i1.linkeepserver.domain.users.dto.LoginReqDTO;
+import com.e2i1.linkeepserver.domain.users.dto.LoginResDTO;
 import com.e2i1.linkeepserver.domain.users.dto.NicknameResDTO;
 import com.e2i1.linkeepserver.domain.users.dto.ProfileResDTO;
+import com.e2i1.linkeepserver.domain.users.dto.SignupReqDTO;
 import com.e2i1.linkeepserver.domain.users.dto.UserHomeResDTO;
 import com.e2i1.linkeepserver.domain.users.entity.UsersEntity;
 import com.e2i1.linkeepserver.domain.users.service.UsersService;
@@ -31,6 +33,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Business
 @RequiredArgsConstructor
 public class UsersBusiness {
+
     private final UsersService usersService;
     private final UsersConverter usersConverter;
 
@@ -40,47 +43,49 @@ public class UsersBusiness {
     private final S3ImageService s3ImageService;
 
     @Transactional
-    public TokenResDTO login(LoginReqDTO loginReqDTO) {
+    public LoginResDTO login(LoginReqDTO loginReqDTO) {
         UsersEntity user = usersService.getUser(loginReqDTO.getEmail());
 
-        // 로그인 시, 해당 유저 없으면 자동 회원가입 진행
+        // 로그인 시, 해당 유저 없으면 랜덤 닉네임만 만들어서 반환
         if (user == null) {
-            String nickname = null;
-            int attempts = 0;
+            String nickname = createRandomNickname();
 
-            // RETRY_NUM 만큼 닉네임 생성 시도
-            while (attempts < RETRY_NUM) {
-                Random random = new Random();
-                int randomNum1 = random.nextInt(WORD_NUM);
-                int randomNum2 = random.nextInt(WORD_NUM);
-                int randomNum3 = random.nextInt(WORD_NUM) + 1;
-
-                // 랜덤 닉네임 만들기
-                nickname = ADJECTIVES.get(randomNum1) + " " + NOUNS.get(randomNum2) + randomNum3;
-
-                // 닉네임 존재하는지 확인
-                Boolean isDuplicated = usersService.isDuplicatedNickname(nickname);
-
-                // 존재하지 않으면 해당 닉네임으로 저장
-                if (!isDuplicated) {
-                    break;
-                }
-
-                // 해당 닉네임 존재 시, 다시 시도
-                attempts++;
-            }
-
-            if (attempts == 10) {
-                throw new ApiException(ErrorCode.RETRY_EXCEEDED);
-            }
-
-            loginReqDTO.setNickname(nickname);
-            UsersEntity newUser = usersConverter.toEntity(loginReqDTO);
-            user = usersService.register(newUser);
+            // 신규 유저면 randomNickname 만들어서 반환하기
+            return LoginResDTO.builder()
+                .existedUser(false)
+                .randomNickname(nickname)
+                .build();
         }
 
-        // 토큰 발행
-        return tokenBusiness.issueToken(user);
+        // 기존 유저면 token 발행해서 반환하기
+        return LoginResDTO.builder()
+            .tokenDTO(tokenBusiness.issueToken(user))
+            .existedUser(true).build();
+    }
+
+
+    /**
+     * 신규 회원 가입 로직
+     */
+    @Transactional
+    public TokenResDTO signup(SignupReqDTO signupInfo, MultipartFile img) {
+        // 닉네임 unique한지 검증
+        if (!validateDuplicatedNickname(signupInfo.getNickname())) {
+            throw new ApiException(ErrorCode.NICKNAME_DUPLICATED);
+        }
+
+        // 이미지 존재하면 S3에 저장하고 URL 반환받기
+        String imgUrl = null;
+        if (img != null && !img.isEmpty()) {
+            imgUrl = s3ImageService.upload(img);
+        }
+
+        // signupInfo(nickname, email 들어있음)와 이미지URL로 UsersEntity 만들고 저장하기
+        UsersEntity newUser = usersConverter.toEntity(signupInfo, imgUrl);
+        newUser = usersService.register(newUser);
+
+        // 저장된 newUser로 token 생성하기
+        return tokenBusiness.issueToken(newUser);
     }
 
     public UserHomeResDTO getUserHome(UsersEntity user) {
@@ -111,12 +116,14 @@ public class UsersBusiness {
     }
 
     @Transactional
-    public void editProfile(MultipartFile imgFile, EditProfileReqDTO editProfile, UsersEntity user) {
+    public void editProfile(MultipartFile imgFile, EditProfileReqDTO editProfile,
+        UsersEntity user) {
         // 기본 값으로 기존 유저의 ImgUrl 사용
         String imgUrl = user.getImgUrl();
 
         // 기존 이미지가 존재하고 이를 삭제하는 경우
-        if (Boolean.TRUE.equals(editProfile.getIsDeletedImg()) && imgUrl != null) { // editProfile.getIsDeletedImg가 null인 경우 false로 인식하기 위해 Boolean.TRUE.equals 사용
+        if (Boolean.TRUE.equals(editProfile.getIsDeletedImg()) && imgUrl
+            != null) { // editProfile.getIsDeletedImg가 null인 경우 false로 인식하기 위해 Boolean.TRUE.equals 사용
             s3ImageService.deleteImageFromS3(user.getImgUrl());
             imgUrl = null;
         }
@@ -133,11 +140,46 @@ public class UsersBusiness {
 
 
     /**
-     * nickname이 유니크하면 true
-     * 유니크하지 않으면 false
+     * nickname이 유니크하면 true 유니크하지 않으면 false
      */
     public Boolean validateDuplicatedNickname(String nickname) {
         Boolean isDuplicated = usersService.isDuplicatedNickname(nickname);
         return !isDuplicated;
+    }
+
+    /**
+     * 랜덤 닉네임 만드는 로직
+     */
+    private String createRandomNickname() {
+        String nickname = null;
+        int attempts = 0;
+
+        // RETRY_NUM 만큼 닉네임 생성 시도
+        while (attempts < RETRY_NUM) {
+            Random random = new Random();
+            int randomNum1 = random.nextInt(WORD_NUM);
+            int randomNum2 = random.nextInt(WORD_NUM);
+            int randomNum3 = random.nextInt(WORD_NUM) + 1;
+
+            // 랜덤 닉네임 만들기
+            nickname = ADJECTIVES.get(randomNum1) + " " + NOUNS.get(randomNum2) + randomNum3;
+
+            // 닉네임 존재하는지 확인
+            Boolean isDuplicated = usersService.isDuplicatedNickname(nickname);
+
+            // 존재하지 않으면 해당 닉네임으로 저장
+            if (!isDuplicated) {
+                break;
+            }
+
+            // 해당 닉네임 존재 시, 다시 시도
+            attempts++;
+        }
+        // 10번 재시도를 넘었다면 에러 발생
+        if (attempts == 10) {
+            throw new ApiException(ErrorCode.RETRY_EXCEEDED);
+        }
+
+        return nickname;
     }
 }

--- a/src/main/java/com/e2i1/linkeepserver/domain/users/controller/UsersController.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/users/controller/UsersController.java
@@ -5,8 +5,10 @@ import com.e2i1.linkeepserver.domain.token.dto.TokenResDTO;
 import com.e2i1.linkeepserver.domain.users.business.UsersBusiness;
 import com.e2i1.linkeepserver.domain.users.dto.EditProfileReqDTO;
 import com.e2i1.linkeepserver.domain.users.dto.LoginReqDTO;
+import com.e2i1.linkeepserver.domain.users.dto.LoginResDTO;
 import com.e2i1.linkeepserver.domain.users.dto.NicknameResDTO;
 import com.e2i1.linkeepserver.domain.users.dto.ProfileResDTO;
+import com.e2i1.linkeepserver.domain.users.dto.SignupReqDTO;
 import com.e2i1.linkeepserver.domain.users.dto.UserHomeResDTO;
 import com.e2i1.linkeepserver.domain.users.entity.UsersEntity;
 import jakarta.validation.Valid;
@@ -65,8 +67,18 @@ public class UsersController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<TokenResDTO> login(@RequestBody LoginReqDTO loginReqDTO) {
-        TokenResDTO response = usersBusiness.login(loginReqDTO);
+    public ResponseEntity<LoginResDTO> login(@RequestBody LoginReqDTO loginReqDTO) {
+        LoginResDTO response = usersBusiness.login(loginReqDTO);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<TokenResDTO> signup(
+        @RequestPart(value = "image", required = false) MultipartFile imgFile,
+        @RequestPart SignupReqDTO signupInfo
+    ) {
+        TokenResDTO response = usersBusiness.signup(signupInfo, imgFile);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/e2i1/linkeepserver/domain/users/controller/UsersController.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/users/controller/UsersController.java
@@ -83,5 +83,13 @@ public class UsersController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(@RequestHeader("authorization-token") String token,
+        @UserSession UsersEntity user) {
+        usersBusiness.logout(token, user);
+
+        return ResponseEntity.ok("로그아웃 되었습니다.");
+    }
+
 
 }

--- a/src/main/java/com/e2i1/linkeepserver/domain/users/converter/UsersConverter.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/users/converter/UsersConverter.java
@@ -1,8 +1,8 @@
 package com.e2i1.linkeepserver.domain.users.converter;
 
 import com.e2i1.linkeepserver.common.annotation.Converter;
-import com.e2i1.linkeepserver.domain.users.dto.LoginReqDTO;
 import com.e2i1.linkeepserver.domain.users.dto.NicknameResDTO;
+import com.e2i1.linkeepserver.domain.users.dto.SignupReqDTO;
 import com.e2i1.linkeepserver.domain.users.entity.UserStatus;
 import com.e2i1.linkeepserver.domain.users.entity.UsersEntity;
 import lombok.RequiredArgsConstructor;
@@ -10,15 +10,13 @@ import lombok.RequiredArgsConstructor;
 @Converter
 @RequiredArgsConstructor
 public class UsersConverter {
-    public UsersEntity toEntity(LoginReqDTO loginReqDTO) {
+    public UsersEntity toEntity(SignupReqDTO signupInfo, String imgUrl) {
         return UsersEntity.builder()
-                .nickname(loginReqDTO.getNickname())
-                .email(loginReqDTO.getEmail())
-                .imgUrl(loginReqDTO.getImgUrl())
-                .thumbnailUrl(loginReqDTO.getImgUrl())
-                .status(UserStatus.REGISTERED)
-                .build();
-
+            .email(signupInfo.getEmail())
+            .nickname(signupInfo.getNickname())
+            .imgUrl(imgUrl)
+            .status(UserStatus.REGISTERED)
+            .build();
     }
 
     public NicknameResDTO toNicknameResponse(UsersEntity user) {

--- a/src/main/java/com/e2i1/linkeepserver/domain/users/dto/LoginResDTO.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/users/dto/LoginResDTO.java
@@ -1,5 +1,6 @@
 package com.e2i1.linkeepserver.domain.users.dto;
 
+import com.e2i1.linkeepserver.domain.token.dto.TokenResDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,6 +10,11 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class LoginReqDTO {
-    private String email;
+public class LoginResDTO {
+    private TokenResDTO tokenDTO;
+
+    private String randomNickname;
+
+    private Boolean existedUser;
+
 }

--- a/src/main/java/com/e2i1/linkeepserver/domain/users/dto/SignupReqDTO.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/users/dto/SignupReqDTO.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class LoginReqDTO {
+public class SignupReqDTO {
     private String email;
+    private String nickname;
 }


### PR DESCRIPTION
## 회원가입
- 신규 회원일 경우, 이미지와 닉네임 입력받는 api 개발

- 기존 회원 가입 api 수정
    - 신규 회원일 경우, 랜덤 닉네임 반환하기 
    - 기존 회원인 경우, access-token 반환하기
    
## 로그아웃 로직 개발
- 로그아웃 요청 시, 해당 token을 DB의 token_black_list 테이블에 저장
- 이후 모든 요청 시, token이 token_black_list 테이블에 저장되어 있는지 검증
    - 저장되어 있다면, 로그아웃 처리된 token임으로 예외 발생
    - 저장되어 있지 않다면, 로그아웃 처리되지 않은 token으로 인정