### PR TITLE
[#18] 커서 기반 페이징 구현 완료

### DIFF
--- a/src/main/java/com/e2i1/linkeepserver/common/constant/PageConst.java
+++ b/src/main/java/com/e2i1/linkeepserver/common/constant/PageConst.java
@@ -1,0 +1,10 @@
+package com.e2i1.linkeepserver.common.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageConst {
+    public static final String DEFAULT_PAGE_SIZE = "10";
+
+}

--- a/src/main/java/com/e2i1/linkeepserver/domain/links/business/LinksBusiness.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/links/business/LinksBusiness.java
@@ -17,6 +17,8 @@ import com.e2i1.linkeepserver.domain.users.entity.UsersEntity;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 @Business
@@ -87,11 +89,19 @@ public class LinksBusiness {
      * 유저가 저장한 모든 link list 불러오기
      * 최신 순으로 정렬해서
      */
-    public List<LinkHomeResDTO> findByUserId(Long userId) {
-        List<LinksEntity> linkList = linksService.findByUserId(userId);
+    public List<LinkHomeResDTO> findByUserId(Long userId, Long lastId, int size) {
+        Pageable pageable = PageRequest.of(0, size);
+        List<LinksEntity> linkList = linksService.findByUserId(userId, lastId, pageable);
 
         return linkList.stream()
             .map(linksConverter::toLinkHomeResponse)
             .collect(Collectors.toList());
+    }
+
+    /**
+     * 다음에 조회될 링크가 있는지 여부
+     */
+    public Boolean hasNext(Long id) {
+        return linksService.hasNext(id);
     }
 }

--- a/src/main/java/com/e2i1/linkeepserver/domain/links/repository/LinksRepository.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/links/repository/LinksRepository.java
@@ -5,6 +5,7 @@ import com.e2i1.linkeepserver.domain.links.entity.LinksEntity;
 import io.lettuce.core.dynamic.annotation.Param;
 import jakarta.persistence.LockModeType;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -24,5 +25,7 @@ public interface LinksRepository extends JpaRepository<LinksEntity, Long> {
 
     List<LinksEntity> findLinksEntitiesByCollection(CollectionsEntity collectionsEntity);
 
-    List<LinksEntity> findByUserIdOrderByUpdateAtDesc(Long userId);
+    List<LinksEntity> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long lastId, Pageable pageable);
+
+    Boolean existsByIdLessThan(Long id);
 }

--- a/src/main/java/com/e2i1/linkeepserver/domain/links/service/LinksService.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/links/service/LinksService.java
@@ -1,13 +1,14 @@
 package com.e2i1.linkeepserver.domain.links.service;
 
 
-import com.e2i1.linkeepserver.domain.collections.entity.CollectionsEntity;
 import com.e2i1.linkeepserver.common.error.ErrorCode;
 import com.e2i1.linkeepserver.common.exception.ApiException;
+import com.e2i1.linkeepserver.domain.collections.entity.CollectionsEntity;
 import com.e2i1.linkeepserver.domain.links.entity.LinksEntity;
 import com.e2i1.linkeepserver.domain.links.repository.LinksRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,7 +47,11 @@ public class LinksService {
         return linksRepository.findByTitleOrDescriptionContainingKeyword(keyword);
     }
 
-    public List<LinksEntity> findByUserId(Long userId) {
-        return linksRepository.findByUserIdOrderByUpdateAtDesc(userId);
+    public List<LinksEntity> findByUserId(Long userId, Long lastId, Pageable pageable) {
+        return linksRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, lastId, pageable);
+    }
+
+    public Boolean hasNext(Long id) {
+        return linksRepository.existsByIdLessThan(id);
     }
 }

--- a/src/main/java/com/e2i1/linkeepserver/domain/users/business/UsersBusiness.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/users/business/UsersBusiness.java
@@ -91,14 +91,20 @@ public class UsersBusiness {
         return tokenBusiness.issueToken(newUser);
     }
 
-    public UserHomeResDTO getUserHome(UsersEntity user) {
-        // user의 모든 link를 최신순으로 가져오기
-        List<LinkHomeResDTO> linkHomeList = linksBusiness.findByUserId(user.getId());
-
+    public UserHomeResDTO getUserHome(Long lastId, Integer size, UsersEntity user) {
+        if (lastId == null) {
+            lastId = Long.MAX_VALUE; // lastId가 null인 경우 가능한 가장 큰 ID부터 시작
+        }
+        // lastId부터 size만큼 링크 가져오기
+        List<LinkHomeResDTO> linkHomeList = linksBusiness.findByUserId(user.getId(), lastId, size);
+        
+        // 가져온 링크들의 마지막 id 값을 가지고 다음에 조회할 링크 있는지 확인
+        Boolean hasNext = linksBusiness.hasNext(linkHomeList.get(linkHomeList.size()-1).getId());
         return UserHomeResDTO.builder()
             .nickname(user.getNickname())
             .imgUrl(user.getImgUrl())
             .linkList(linkHomeList)
+            .hasNext(hasNext)
             .build();
     }
 

--- a/src/main/java/com/e2i1/linkeepserver/domain/users/controller/UsersController.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/users/controller/UsersController.java
@@ -1,5 +1,7 @@
 package com.e2i1.linkeepserver.domain.users.controller;
 
+import static com.e2i1.linkeepserver.common.constant.PageConst.DEFAULT_PAGE_SIZE;
+
 import com.e2i1.linkeepserver.common.annotation.UserSession;
 import com.e2i1.linkeepserver.domain.token.dto.TokenResDTO;
 import com.e2i1.linkeepserver.domain.users.business.UsersBusiness;
@@ -12,12 +14,19 @@ import com.e2i1.linkeepserver.domain.users.dto.SignupReqDTO;
 import com.e2i1.linkeepserver.domain.users.dto.UserHomeResDTO;
 import com.e2i1.linkeepserver.domain.users.entity.UsersEntity;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
@@ -29,8 +38,9 @@ public class UsersController {
     private final UsersBusiness usersBusiness;
 
     @GetMapping("/home")
-    public ResponseEntity<UserHomeResDTO> getUserHome(@UserSession UsersEntity user) {
-        UserHomeResDTO home = usersBusiness.getUserHome(user);
+    public ResponseEntity<UserHomeResDTO> getUserHome(@RequestParam(value = "lastId", required = false) Long lastId,
+        @RequestParam(value = "size", defaultValue = DEFAULT_PAGE_SIZE) Integer size, @UserSession UsersEntity user) {
+        UserHomeResDTO home = usersBusiness.getUserHome(lastId, size, user);
 
         return ResponseEntity.ok(home);
     }

--- a/src/main/java/com/e2i1/linkeepserver/domain/users/dto/UserHomeResDTO.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/users/dto/UserHomeResDTO.java
@@ -15,4 +15,5 @@ public class UserHomeResDTO {
     private String nickname;
     private String imgUrl;
     private List<LinkHomeResDTO> linkList;
+    private Boolean hasNext; // 커서 기반 페이징할 때, 끝인지 아닌지 알려주는 변수
 }


### PR DESCRIPTION
- 유저의 홈 화면에서 링크 타임라인 구현 시, 무한 스크롤 기능을 위해 커서 기반 페이징 구현

- 최초 조회 시, `lastId` 값은 Long의 최댓값으로 들어감
- 이후 `lastId` 값보다 작은 id를 가진 링크를 `size` 만큼 가져옴