### PR TITLE
[#39] SignupReqDTO 수정, 닉네임 중복 체크 수정

### DIFF
--- a/src/main/java/com/e2i1/linkeepserver/config/WebConfig.java
+++ b/src/main/java/com/e2i1/linkeepserver/config/WebConfig.java
@@ -21,7 +21,8 @@ public class WebConfig implements WebMvcConfigurer {
         "favicon.ico",
         "/error",
         "/api/users/login",
-        "/api/users/register"
+        "/api/users/register",
+        "/api/users/check-duplicated-nickname"
     );
 
     private final List<String> SWAGGER = List.of(

--- a/src/main/java/com/e2i1/linkeepserver/domain/users/converter/UsersConverter.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/users/converter/UsersConverter.java
@@ -14,6 +14,7 @@ public class UsersConverter {
         return UsersEntity.builder()
             .email(signupInfo.getEmail())
             .nickname(signupInfo.getNickname())
+            .description(signupInfo.getDescription())
             .imgUrl(imgUrl)
             .status(UserStatus.REGISTERED)
             .build();

--- a/src/main/java/com/e2i1/linkeepserver/domain/users/dto/SignupReqDTO.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/users/dto/SignupReqDTO.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class SignupReqDTO {
     private String email;
     private String nickname;
+    private String description;
 }


### PR DESCRIPTION
## 닉네임 중복 체크 수정
- access token 없이 호출할 수 있도록 수정

## SignupReqDTO 수정
- 회원 가입 시, 한 줄 소개 저장할 `description` 속성 누락한거 추가