### PR TITLE
[#42] 링크 검색 페이징, 프로필 수정 오류 해결, 정규 표현식 최적화, DB 쿼리 발생 횟수 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     //developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/com/e2i1/linkeepserver/domain/links/controller/LinksController.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/links/controller/LinksController.java
@@ -1,5 +1,7 @@
 package com.e2i1.linkeepserver.domain.links.controller;
 
+import static com.e2i1.linkeepserver.common.constant.PageConst.DEFAULT_PAGE_SIZE;
+
 import com.e2i1.linkeepserver.common.annotation.UserSession;
 import com.e2i1.linkeepserver.domain.links.business.LinksBusiness;
 import com.e2i1.linkeepserver.domain.links.dto.LinkReqDTO;
@@ -7,7 +9,6 @@ import com.e2i1.linkeepserver.domain.links.dto.LinkResDTO;
 import com.e2i1.linkeepserver.domain.links.dto.SearchLinkResDTO;
 import com.e2i1.linkeepserver.domain.users.entity.UsersEntity;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -28,10 +29,14 @@ public class LinksController {
     private final LinksBusiness linksBusiness;
 
     @GetMapping()
-    public ResponseEntity<List<SearchLinkResDTO>> searchLink(
-        @RequestParam("search") String keyword) {
+    public ResponseEntity<SearchLinkResDTO> searchLink(
+        @RequestParam(value = "search") String keyword,
+        @RequestParam(value = "view", required = false) Long view,
+        @RequestParam(value = "lastId", required = false) Long lastId,
+        @RequestParam(value = "size", defaultValue = DEFAULT_PAGE_SIZE) Integer size
+    ) {
         log.info("search keyword = {}", keyword);
-        List<SearchLinkResDTO> searchLinks = linksBusiness.searchLinks(keyword);
+        SearchLinkResDTO searchLinks = linksBusiness.searchLinks(keyword, view, lastId, size);
         return ResponseEntity.ok(searchLinks);
     }
 

--- a/src/main/java/com/e2i1/linkeepserver/domain/links/converter/LinksConverter.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/links/converter/LinksConverter.java
@@ -5,7 +5,7 @@ import com.e2i1.linkeepserver.domain.collections.dto.CollectionLinkDTO;
 import com.e2i1.linkeepserver.domain.collections.entity.CollectionsEntity;
 import com.e2i1.linkeepserver.domain.links.dto.LinkReqDTO;
 import com.e2i1.linkeepserver.domain.links.dto.LinkResDTO;
-import com.e2i1.linkeepserver.domain.links.dto.SearchLinkResDTO;
+import com.e2i1.linkeepserver.domain.links.dto.SearchLinkDTO;
 import com.e2i1.linkeepserver.domain.links.entity.LinksEntity;
 import com.e2i1.linkeepserver.domain.users.dto.LinkHomeResDTO;
 import com.e2i1.linkeepserver.domain.users.entity.UsersEntity;
@@ -51,8 +51,8 @@ public class LinksConverter {
             .build();
     }
 
-    public SearchLinkResDTO toSearchResponse(LinksEntity link) {
-        return SearchLinkResDTO.builder()
+    public SearchLinkDTO toSearchResponse(LinksEntity link) {
+        return SearchLinkDTO.builder()
             .title(link.getTitle())
             .url(link.getUrl())
             .description(link.getDescription())
@@ -68,6 +68,7 @@ public class LinksConverter {
             .title(link.getTitle())
             .url(link.getUrl())
             .description(link.getDescription())
+            .numOfViews(link.getNumOfViews())
             .updatedAt(link.getUpdateAt())
             .build();
     }

--- a/src/main/java/com/e2i1/linkeepserver/domain/links/dto/SearchLinkDTO.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/links/dto/SearchLinkDTO.java
@@ -1,6 +1,5 @@
 package com.e2i1.linkeepserver.domain.links.dto;
 
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,9 +9,12 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class SearchLinkResDTO {
-
-    List<SearchLinkDTO> searchLinkList;
-    Boolean hasNext;
+public class SearchLinkDTO {
+    private String title;
+    private String url;
+    private String description;
+    private Long numOfViews;
+    private Long linkId;
+    private Long writer;
 
 }

--- a/src/main/java/com/e2i1/linkeepserver/domain/links/repository/LinksRepository.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/links/repository/LinksRepository.java
@@ -5,10 +5,9 @@ import com.e2i1.linkeepserver.domain.links.entity.LinksEntity;
 import io.lettuce.core.dynamic.annotation.Param;
 import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
@@ -17,15 +16,16 @@ public interface LinksRepository extends JpaRepository<LinksEntity, Long> {
     @Lock(LockModeType.OPTIMISTIC)
     Optional<LinksEntity> findFirstByIdOrderByIdDesc(Long linkId);
 
-    @Query("select l from LinksEntity l where "
-        + "REPLACE(lower(l.title), ' ', '' ) LIKE CONCAT('%', lower(:keyword), '%') "
-        + "OR REPLACE(lower(l.description), ' ', '' ) LIKE CONCAT('%', lower(:keyword), '%') "
-        + "order by l.numOfViews desc ")
-    List<LinksEntity> findByTitleOrDescriptionContainingKeyword(@Param("keyword") String keyword);
+    @Query("SELECT l FROM LinksEntity l "
+        + "WHERE (REPLACE(lower(l.title), ' ', '' ) LIKE CONCAT('%', lower(:keyword), '%') "
+        + "OR REPLACE(lower(l.description), ' ', '' ) LIKE CONCAT('%', lower(:keyword), '%')) "
+        + "AND (l.numOfViews < :view OR (l.numOfViews = :view AND l.Id > :lastId))"
+        + "ORDER BY l.numOfViews desc, l.Id ASC ")
+    List<LinksEntity> findByTitleOrDescriptionContainingKeyword(@Param("keyword") String keyword,
+        @Param("view") Long view, @Param("lastId") Long lastId, Pageable pageable);
 
     List<LinksEntity> findLinksEntitiesByCollection(CollectionsEntity collectionsEntity);
 
     List<LinksEntity> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long lastId, Pageable pageable);
 
-    Boolean existsByIdLessThan(Long id);
 }

--- a/src/main/java/com/e2i1/linkeepserver/domain/links/service/LinksService.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/links/service/LinksService.java
@@ -43,15 +43,12 @@ public class LinksService {
     }
 
 
-    public List<LinksEntity> searchLinks(String keyword) {
-        return linksRepository.findByTitleOrDescriptionContainingKeyword(keyword);
+    public List<LinksEntity> searchLinks(String keyword, Long view, Long lastId, Pageable pageable) {
+        return linksRepository.findByTitleOrDescriptionContainingKeyword(keyword, view, lastId, pageable);
     }
 
     public List<LinksEntity> findByUserId(Long userId, Long lastId, Pageable pageable) {
         return linksRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, lastId, pageable);
     }
 
-    public Boolean hasNext(Long id) {
-        return linksRepository.existsByIdLessThan(id);
-    }
 }

--- a/src/main/java/com/e2i1/linkeepserver/domain/users/business/UsersBusiness.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/users/business/UsersBusiness.java
@@ -97,9 +97,10 @@ public class UsersBusiness {
         }
         // lastId부터 size만큼 링크 가져오기
         List<LinkHomeResDTO> linkHomeList = linksBusiness.findByUserId(user.getId(), lastId, size);
-        
-        // 가져온 링크들의 마지막 id 값을 가지고 다음에 조회할 링크 있는지 확인
-        Boolean hasNext = linksBusiness.hasNext(linkHomeList.get(linkHomeList.size()-1).getId());
+
+        boolean hasNext = linkHomeList.size() > size;
+        if (hasNext) linkHomeList = linkHomeList.subList(0, size);
+
         return UserHomeResDTO.builder()
             .nickname(user.getNickname())
             .imgUrl(user.getImgUrl())

--- a/src/main/java/com/e2i1/linkeepserver/domain/users/dto/LinkHomeResDTO.java
+++ b/src/main/java/com/e2i1/linkeepserver/domain/users/dto/LinkHomeResDTO.java
@@ -16,5 +16,6 @@ public class LinkHomeResDTO {
     private String title;
     private String url;
     private String description;
+    private Long numOfViews;
     private LocalDateTime updatedAt;
 }


### PR DESCRIPTION
## 링크 검색 결과 커서 기반 페이징

## 프로필 수정 오류
- 닉네임 공백 입력 시, 검증되지 않고 DB에 반영되던 오류 해결

-> build.gradle에 spring-boot-starter-validation 없어서 검증 애노테이션 적용 실패했던 것

## 정규 표현식 최적화
- 메서드 호출될 때마다 컴파일되던 정규 표현식을 사전에 컴파일 해놓고 재사용하도록 코드 수

## DB 쿼리 발생횟수 최적화
- 페이징에서 다음 페이지 있는지 알기 위해 추가적으로 쿼리 발생하는 걸 없앰
- size+1개만큼 조회하고 결과 개수가 size+1개 미만이면 다음 페이지 없다는 의미로 판단 
- 이를 통해 추가적으로 발생하던 쿼리 1개 줄임